### PR TITLE
Remove space from being added in the final URL.

### DIFF
--- a/scripts/onelink-smart-script.js
+++ b/scripts/onelink-smart-script.js
@@ -142,7 +142,7 @@ function getParameterFromURL(name) {
         results = regex.exec(url);
     if (!results) return null;
     if (!results[2]) return '';
-    return decodeURIComponent(results[2].replace(/\+/g, ' '));
+    return decodeURIComponent(results[2].replace(/\+/g, ''));
 }
 
 function getMediaSourceValue(pidKeysList, pidStaticValue, pidOverrideList){


### PR DESCRIPTION
The current logic results in a space (" ") being used in the resulting URL - this breaks the link. 
